### PR TITLE
Fix BigInt seeding

### DIFF
--- a/pcg-random.js
+++ b/pcg-random.js
@@ -121,10 +121,10 @@ var PcgRandom = (function() {
 			if (seedHi != null && typeof seedHi != 'bigint') {
 				throw new TypeError('non-bigint used for `inc` when `seed` is provided');
 			}
+			var bU32Max = BigInt(0xffffffff);
+			var b32 = BigInt(32);
 			sl32 = Number(seedLo & bU32Max);
 			sh32 = Number((seedLo >> b32) & bU32Max);
-			var b32 = BigInt(32);
-			var bU32Max = BigInt(0xffffffff);
 			if (typeof seedHi === "bigint") {
 				// We need to do `(inc << 1) | 1` to match PCG.
 				var b1 = BigInt(1);

--- a/test/bigint.js
+++ b/test/bigint.js
@@ -1,0 +1,12 @@
+var test = require('tape');
+var PcgRandom = require('../pcg-random.js');
+
+test('BigInt seeding', function(t) {
+    var pcg1 = new PcgRandom(BigInt('0x2210ca8399dc2e37'), BigInt('0x14057b7ef767814f'));
+    var pcg2 = new PcgRandom(0x99dc2e37, 0x2210ca83, 0xf767814f, 0x14057b7e);
+    var state1 = pcg1.getState();
+    var state2 = pcg2.getState();
+    t.deepEqual(pcg1.getState().slice(0, 2), pcg2.getState().slice(0, 2), 'Initial pcg state');
+    t.deepEqual(pcg1.getState().slice(2, 4), pcg2.getState().slice(2, 4), 'Initial pcg increment');
+    t.end();
+});


### PR DESCRIPTION
The issue can be reproduced with:

```js
const PcgRandom = require("pcg-random")

const r = new PcgRandom();

r.setSeed(BigInt('1'), BigInt('1'));
```

Currently `seedLo & bU32Max` is a TypeError since `bU32Max` is only defined later